### PR TITLE
Rewrite LQIP template to be more compact

### DIFF
--- a/src/lqip.js
+++ b/src/lqip.js
@@ -1,12 +1,10 @@
 const svgToMiniDataURI = require('mini-svg-data-uri');
 
 const {dataURI} = require('./utils');
-const {LQIP_WIDTH} = require('./constants');
 
-module.exports = (source, {width, height, mimetype, filename}) => {
+module.exports = (source, {mimetype, filename}) => {
   const id = `lqip-${filename.replace(/(\.|\s)/g, '-')}`;
   const lqip = dataURI(source, mimetype);
-  const h = Math.round(LQIP_WIDTH * height / width);
-  const template = `<svg width="${LQIP_WIDTH}" height="${h}" viewBox="0 0 ${LQIP_WIDTH} ${h}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><filter id="${id}"><feGaussianBlur stdDeviation="2" /><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0" /><feComposite in2="SourceGraphic" operator="in" /></filter><image filter="url(#${id})" height="100%" width="100%" xlink:href="${lqip}" /></svg>`;
+  const template = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:x="http://www.w3.org/1999/xlink"><filter id="${id}"><feGaussianBlur stdDeviation="2"/><feColorMatrix type="matrix" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 2 0"/></filter><image height="100%" width="100%" x:href="${source}" preserveAspectRatio="xMidYMid slice" filter="url(#${id})"/></svg>`;
   return svgToMiniDataURI(template);
 };


### PR DESCRIPTION
* No need for `viewBox`, because the contents are always sized to be 100%&times;100%
* `width`/`height` on the root `<svg>` are assumed to be 100% if omitted, so consumers no longer have to use CSS to stretch the LQIP over the full area
* `preserveAspectRatio="xMidYMid slice"` is how SVG says `object-fit: cover; object-position: center`
* XLink namespace bound to `x`, saving some characters
* `<feComposite>` not actually needed